### PR TITLE
Vine grind

### DIFF
--- a/Assets/Scenes/MovementDemoScene.unity
+++ b/Assets/Scenes/MovementDemoScene.unity
@@ -4552,7 +4552,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1644975654}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 78.5, y: 8.15, z: 0}
+  m_LocalPosition: {x: 103.8, y: 7.7, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scenes/MovementDemoScene.unity
+++ b/Assets/Scenes/MovementDemoScene.unity
@@ -4485,6 +4485,7 @@ GameObject:
   - component: {fileID: 1644975655}
   - component: {fileID: 1644975658}
   - component: {fileID: 1644975657}
+  - component: {fileID: 1644975659}
   m_Layer: 6
   m_Name: temp3
   m_TagString: Untagged
@@ -4627,6 +4628,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   scrollRate: 1
+--- !u!114 &1644975659
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1644975654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6bb195d0577da5a394bd51dcc53ac51, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TiltDegreesPerSecond: 20
 --- !u!1 &1684612392
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Movement/PlayerMovement.cs
+++ b/Assets/Scripts/Movement/PlayerMovement.cs
@@ -279,6 +279,11 @@ public class PlayerMovement : MonoBehaviour
 
     bool LandingCheck()
     {
+        if (this.velocity.y > 1) {
+            return false;
+        }
+
+
         // landing check consists of: a circle around the skateboard (casted along the velocity for continuous detection between frames) ...
         bool circleHits =
             Physics2D.CircleCast(skateboardCenter.position, .5f, velocity.normalized, velocity.magnitude * Time.deltaTime, currentSkateableLayer);
@@ -405,7 +410,7 @@ public class PlayerMovement : MonoBehaviour
             // find the ground below the board, at 3 different offsets
             (bool _, Vector2 midPoint) = move.GroundCast(move.midPointOffset);
             (bool _, Vector2 slopeCheckPoint) = move.GroundCast(move.slopeCheckXOffset);
-            (bool _, Vector2 _) = move.GroundCast(move.groundCheckXOffset);
+            //(bool _, Vector2 _) = move.GroundCast(move.groundCheckXOffset);
 
             Vector2 groundTangent = (slopeCheckPoint - midPoint).normalized;
 

--- a/Assets/Scripts/Vine.cs
+++ b/Assets/Scripts/Vine.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Vine : MonoBehaviour
+{
+    public float TiltDegreesPerSecond = 20;
+}

--- a/Assets/Scripts/Vine.cs.meta
+++ b/Assets/Scripts/Vine.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6bb195d0577da5a394bd51dcc53ac51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- [x] Add event for when the player is on and leaves a vine
- [ ] Add mechanism for player to gain extra points when on a vine

In the current implementation, vines are currently the same as the ground edge colliders the player grinds on. The difference being that the player rotates when on the vine, falls through the vine when that rotation goes too far, and the A and D keys are used for rotation instead of acceleration.


https://user-images.githubusercontent.com/29179327/236582243-dbb3eaab-9cc0-47ac-a115-2cf327727f70.mp4

